### PR TITLE
runtime: Update to GNOME 48

### DIFF
--- a/com.github.johnfactotum.QuickLookup.json
+++ b/com.github.johnfactotum.QuickLookup.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.johnfactotum.QuickLookup",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "quick-lookup",
     "finish-args": [


### PR DESCRIPTION
New runtime brings altered dark theme and corner radii of Libadwaita 1.7